### PR TITLE
Homepage feature icons - prevents full width

### DIFF
--- a/layouts/partials/home-page-sections/features-icons.html
+++ b/layouts/partials/home-page-sections/features-icons.html
@@ -5,7 +5,7 @@
       {{ range $i, $e := $features  }}
         {{ $features_count := $e | len }}
 
-        <div class="w-100{{ if eq $i $features_count }} w-70-ns {{ else }} w-50-ns {{ end }}ph5-l pv5-l nested-copy-line-height">
+        <div class="w-100{{ if and (eq $i $features_count) (ne (modBool $features_count 2) true) }} w-70-ns {{ else }} w-50-ns {{ end }}ph5-l pv5-l nested-copy-line-height">
           <!-- NOTE:  "if eq $i $features_count" makes the last item a bit wider for balance. If we use an even number of items, we'll want to remove this -->
           <div class="flex-l flex-wrap justify-between">
             <div class="flex-auto w-100 w-20-ns pt1 ">


### PR DESCRIPTION
Prevents the last two features from taking full width on desktop screen. Figure adding a `modbool` makes this more flexible in the event that we want to add/remove feature blocks in the future.