### PR TITLE
Update site search to use the ID "search-input"

### DIFF
--- a/layouts/partials/site-search.html
+++ b/layouts/partials/site-search.html
@@ -1,6 +1,6 @@
 <form id="site-search-form" action="" role="search">
   <fieldset class="bn ma0 pa0">
-    <label class="clip" for="email-address">Search</label>
-    <input type="search" id="search-input" class="needs-js bg-left bg-transparent bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" type="text" name="email-address" value="" style="background-image:url('/images/icon-search.png');background-size:16px 16px;">
+    <label class="clip" for="search-input">Search</label>
+    <input type="search" id="search-input" class="needs-js bg-left bg-transparent bn f5 input-reset lh-solid mt3 mt0-ns pl4 pv2 w5 white" placeholder="Search the Docs" type="text" name="search-input" value="" style="background-image:url('/images/icon-search.png');background-size:16px 16px;">
   </fieldset>
 </form>


### PR DESCRIPTION
The search input in the header of all pages currently has:

* An `id` of `search-input`
* A name of `email-address`
* The label for the input has a `for` of `email-address`

I've standardised these to all be `search-input` which now associates the label with the input :)