### PR TITLE
Fix "reflect: Zero(nil)" error in showcase

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,7 +13,7 @@
 
   {{- partial "home-page-sections/features-single" . -}}
 
-  {{- partial "home-page-sections/showcase.html" . -}} 
+  {{- partial "home-page-sections/showcase.html" . -}}
 
   <section class="w-100 ph4 ph5-ns pv4 pv6-ns mid-gray bg-white bb bt b--light-gray">
     {{- partial "home-page-sections/installation" . -}}

--- a/layouts/partials/home-page-sections/showcase.html
+++ b/layouts/partials/home-page-sections/showcase.html
@@ -5,9 +5,11 @@
     <div class="w-100 overflow-x-scroll">
       <div class="row nowrap mv2 pb1">
         {{ $showcasePages := where .Site.RegularPages "Section" "showcase" }}
+        {{ if $showcasePages }}
         {{ template "home_showcase_item" (index $showcasePages 0) }}
         {{ range $p := first 10 ($showcasePages | after 1 | shuffle) }}
           {{template "home_showcase_item" $p }}
+        {{end}}
         {{end}}
       </div>
     </div>


### PR DESCRIPTION
when a showcase bundle does not yet exist for a new language.

Special thanks to @bep for the suggested fix.

See gohugoio/hugoDocs#461