### PR TITLE
Update "Contributors" link in site-footer.html

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -3,7 +3,7 @@
       <div class="pb3 pt4 w-100 w-50-ns">
 
          <div class="b f3  light-gray mb3 nested-links tc">
-           By the <a href="https://github.com/gohugoio/hugo/contributors" class="link">Hugo Authors</a><br />
+           By the <a href="https://github.com/gohugoio/hugo/graphs/contributors" class="link">Hugo Authors</a><br />
           </div>
 
           <div class="center w4">


### PR DESCRIPTION
The "Hugo Authors" link to Contributors is out of sync with the one found in the "Releases" page, for example. Both links currently resolve to the same destination.

If this continues to be the case going forward, then it is not a big deal. However, it is always best to keep links consistent to avoid possible broken links in the future.

The Release version is the most up-to-date as it is also used in other places in GitHub. The older link may become deprecated in future.