### PR TITLE
docs(partials): remove extra slash in page metadata

### DIFF
--- a/layouts/partials/docs/page-meta-data.html
+++ b/layouts/partials/docs/page-meta-data.html
@@ -2,5 +2,5 @@
   <a href="{{ .Permalink }}" class="hide-child link primary-color">
   <span class="nl3 child">{{ partial "svg/link-permalink.svg" (dict "size" "14px") }}</span>
     “{{ .Title }}”
-  </a> was last updated: {{ .Lastmod.Format "January 2, 2006" }}{{ with .GitInfo }}: <a class="hide-child link primary-color" href="{{$.Site.Params.ghrepo}}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+  </a> was last updated: {{ .Lastmod.Format "January 2, 2006" }}{{ with .GitInfo }}: <a class="hide-child link primary-color" href="{{$.Site.Params.ghrepo}}commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
 </h6>


### PR DESCRIPTION
URL was being displayed as 'https://domain.tld//commit/hash'