### PR TITLE
Remove unneeded HandheldFriendly and MobileOptimized meta tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,8 +10,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
      {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
     <title>{{ block "title" . }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <meta name="HandheldFriendly" content="True">
-    <meta name="MobileOptimized" content="320">
 
     <meta name="viewport" content="width=device-width,minimum-scale=1">
      {{ .Hugo.Generator }}


### PR DESCRIPTION
```
<meta name="HandheldFriendly" content="True">
<meta name="MobileOptimized" content="320">
```
I realise that these meta tags aren't doing any harm - but they are not needed at all and take up a few bytes of every page loading.

- The `HandheldFriendly` meta tag was used for a very old version of BlackBerry.
REF: https://developer.blackberry.com/playbook/html5/documentation/handheldfriendly.html

- The `MobileOptimized` meta tag was used for a very old version of Windows Mobile 5 / 6 (before even Windows Phone 7, 8 and Windows Mobile 10!).