### PR TITLE
Use 'w' units instead of 'x' for responsive images in showcase

### DIFF
--- a/layouts/showcase/single.html
+++ b/layouts/showcase/single.html
@@ -35,9 +35,16 @@ Showcase: {{ .Title }}
 {{define "sc-main-column"}}
   {{ $img := (.Resources.ByType "image").GetMatch "*featured*" }}
   {{ with $img }}
-     {{ $big := .Fill "1024x512 top" }}
-     {{ $small := $big.Resize "512x" }}
-      <img srcset="{{ $small.RelPermalink }} 1x, {{ $big.RelPermalink }} 2x" alt="{{ $img.Title }}" width="{{ $big.Width }}"  class="mw-100 b--light-gray ba">
+    {{ $big := .Fill "1024x512 top" }}
+    {{ $small := $big.Resize "512x" }}
+    <img
+      alt="{{ $img.Title }}"
+      src="{{ $big.RelPermalink }}"
+      srcset="{{ $small.RelPermalink }} 512w, {{ $big.RelPermalink }} 1024w"
+      sizes="(min-width: 1570px) 822px, (max-width: 1569px) and (min-width: 960px) 50vw, 93vw"
+      width="{{ $big.Width }}"
+      class="mw-100 b--light-gray ba"
+    >
   {{ end }}
    <div class="mid-gray nested-copy-line-height nested-img nested-links">
   {{with .Params.byline }}


### PR DESCRIPTION
The images on the showcase are blurry on larger screens at 1x displays. On a 1x screen, the largest image you are served is 512px, but it's stretched up to ~800px, which is causing the quality to drop.

This PR uses `w` units instead of `x` to check the screen width, and serve a more appropriate image depending on your screen size.

Tested on a 24" 1x display, and a 15" Retina Macbook Pro.

Before:

![image](https://user-images.githubusercontent.com/3949335/49669244-ad846080-fa58-11e8-9510-fb9405327eaa.png)

After:

![image](https://user-images.githubusercontent.com/3949335/49669294-dad10e80-fa58-11e8-9374-8d0b22a78d19.png)
