### PR TITLE
Normalize package.json.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -2,8 +2,16 @@
   "name": "gohugo-default-styles",
   "version": "1.0.0",
   "description": "Default Theme for Hugo Sites",
+  "private": true,
   "main": "index.js",
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gohugoio/gohugoioTheme.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gohugoio/gohugoioTheme/issues"
+  },
+  "homepage": "https://github.com/gohugoio/gohugoioTheme#readme",
   "author": "budparr",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
* specify `private: true` since the package isn't published on npm
* add missing repository, bug and homepage properties