### PR TITLE
Remove Google News Meta tag (deprecated)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,7 +37,6 @@
       {{ partial "site-manifest.html" . }}
       {{- partial "head-additions.html" . -}}
       {{- template "_internal/opengraph.html" . -}}
-      {{- template "_internal/google_news.html" . -}}
       {{- template "_internal/schema.html" . -}}
       {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
Google no longer supports the meta news tag so should remove it here 
REF: https://searchengineland.com/google-drops-support-meta-news-keywords-tag-292493