### PR TITLE
Hardcoded hugo website

### DIFF
--- a/layouts/partials/site-nav.html
+++ b/layouts/partials/site-nav.html
@@ -4,7 +4,7 @@
   <div class="center flex-ns flex-wrap items-center justify-start mw9">
 
     <h1 class="dim f3 lh-solid ml0-ns mr0 mr4-l mv0 pl3 pl4-ns">
-      <a href="{{ .Site.BaseURL }}" class="link white">
+      <a href="https://gohugo.io/" class="link white">
          HUGO
       </a>
     </h1>


### PR DESCRIPTION
In relation to https://github.com/gohugoio/hugoDocs/issues/758

This change also means that the URL for the `HUGO` on top left can be updated from one place and does not have to be separately updated in different `config.toml` (themes, docs, etc.)