### PR TITLE
Stop waiting for async state in gtag handler

### DIFF
--- a/layouts/partials/gtag.html
+++ b/layouts/partials/gtag.html
@@ -17,8 +17,7 @@ var trackOutboundLink = function(id, url) {
   gtag('event', 'click', {
     'event_category': 'outbound',
     'event_label': id,
-    'transport_type': 'beacon',
-    'event_callback': function(){document.location = url;}
+    'transport_type': 'beacon'
   });
 }
 

--- a/layouts/partials/home-page-sections/sponsors.html
+++ b/layouts/partials/home-page-sections/sponsors.html
@@ -13,7 +13,7 @@
                 {{ $url := printf "%s?%s" . (querify "utm_source" "homepage" "utm_medium" "banner" "utm_campaign" "hugosponsor") | safeURL }}
                 {{ if eq (getenv "HUGO_ENV") "production" | or (eq $.cx.Site.Params.env "production")  }}
                    {{ $gtagID := printf "Sponsor %s %s" $banner.name $gtag | title }}
-                   <a href="{{ $url }}" onclick="trackOutboundLink({{ printf "'%s', '%s'" $gtagID $url | safeJS }}); return false;" class="grow">
+                   <a href="{{ $url }}" onclick="trackOutboundLink({{ printf "'%s', '%s'" $gtagID $url | safeJS }});" class="grow">
                 {{ else }}
                    <a href="{{ $url }}" class="grow">
                 {{ end }}


### PR DESCRIPTION
As mentioned in the issue I linked below, waiting for the `event_callback` degrades the user experience, and the current implementation overrides default browser behaviour with regards to opening links in new tabs / windows.

Closes [#1169](https://github.com/gohugoio/hugoDocs/issues/1169)
Closes [discourse](https://discourse.gohugo.io/t/sponsor-links-on-documentation-homepage-are-not-respecting-default-browser-behaviour/26843)