### PR TITLE
widen the main content column

### DIFF
--- a/assets/output/css/app.css
+++ b/assets/output/css/app.css
@@ -4083,7 +4083,7 @@ img { max-width: 100%; }
     max-width: 30em;
   }
   .measure-wide-l {
-    max-width: 34em;
+    max-width: 40em;
   }
   .measure-narrow-l {
     max-width: 20em;


### PR DESCRIPTION
The central column is restricted to a max-width of just 544px (34em) which means lots of empty space and more scrolling is necessary to read the docs.

Widening it slightly makes it more readable and looks nicer I think.

It also means that full-width images, such as diagrams are easier to read and YouTube vids appear larger (see screenshots below)