### PR TITLE
fix unnecessary scrollbar on code snippets

### DIFF
--- a/assets/css/_code.css
+++ b/assets/css/_code.css
@@ -9,12 +9,6 @@
   margin: 0;
 }
 
-pre, .pre  {
-  overflow-x: auto;
-  overflow-y: hidden;
-  overflow:   scroll;
-}
-
 code {
     padding: 0.2em;
     margin: 0;
@@ -23,15 +17,13 @@ code {
     border-radius: 3px;
 }
 
-
-pre  code {
+pre code {
   display: block;
   padding: 1.5em 1.5em;
   font-size: .875rem;
   line-height: 2;
   overflow-x: auto;
 }
-
 
 pre {
   background-color: #fff;


### PR DESCRIPTION
Removing this CSS:

```css
pre, .pre {
  overflow-x: auto;
  overflow-y: hidden;
  overflow: scroll;
}
```
Fixes the unnecessary scrollbar on code snippets. Saves room and looks nicer. :-)

BEFORE:
![image](https://user-images.githubusercontent.com/1212885/114142295-bf8aac80-994d-11eb-899e-aa811c99822d.png)

AFTER:
![image](https://user-images.githubusercontent.com/1212885/114142365-d3361300-994d-11eb-8f99-90ba3625651a.png)
