### PR TITLE
Small UI change to 'Last updated' info at bottom of article

### DIFF
--- a/layouts/partials/docs/page-meta-data.html
+++ b/layouts/partials/docs/page-meta-data.html
@@ -1,6 +1,3 @@
-<h6 class="f4 dark-gray mb2">
-  <a href="{{ .Permalink }}" class="hide-child link primary-color">
-  <span class="nl3 child">{{ partial "svg/link-permalink.svg" (dict "size" "14px") }}</span>
-    “{{ .Title }}”
-  </a> was last updated: {{ .Lastmod.Format "January 2, 2006" }}{{ with .GitInfo }}: <a class="hide-child link primary-color" href="{{$.Site.Params.ghrepo}}commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+<h6 class="f6 dark-gray mb2">
+  Last updated: {{ .Lastmod.Format "January 2, 2006" }}{{ with .GitInfo }}: <a class="hide-child link primary-color" href="{{$.Site.Params.ghrepo}}commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
 </h6>


### PR DESCRIPTION
I thought the 'Last updated' section was displaying too big and prominent, so this PR makes it smaller.

- Smaller text (change from `f4` to `f6`)
- Remove unnecessary page title with link to the same page