### PR TITLE
Fix: partial 'Site nav' produces invalid html

### DIFF
--- a/layouts/partials/site-nav.html
+++ b/layouts/partials/site-nav.html
@@ -8,7 +8,7 @@
          HUGO
       </a>
     </h1>
-    <ul class="list ma0 pa0 dn dib-l">
+    <ul class="list ma0 pa0 dn dib-l" role="menu">
       {{ range .Site.Menus.global }}
         <li class="f5 dib mr4" role="menuitem">
             {{/* TODO: Create an "Global" active class to show which site one is currently at */}}


### PR DESCRIPTION
**Check of hugo documentation site with [W3C validation service](https://validator.w3.org/nu/?doc=https%3A%2F%2Fgohugo.io%2Fdocumentation%2F):**

Several errors of this kind are reported:

- An element with role=menuitem must be contained in, or owned by, an element with role=menubar or role=menu.

This PR fixes these errors.