### PR TITLE
Add `.html` suffix to partial usage

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -52,13 +52,13 @@
   {{- partial "opengraph/twitter_cards.html" . -}}
 
   {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-  {{ partial "gtag" . }}
+  {{ partial "gtag.html" . }}
   {{ end }}
 
 </head>
 
 <body class="ma0 sans-serif bg-primary-color-light{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
-  {{ partial "hooks/after-body-start" . }}
+  {{ partial "hooks/after-body-start.html" . }}
   {{ block "nav" . }}{{ partial "site-nav.html" . }}{{ end }}
   {{ block "header" . }}{{ end }}
   <main role="main" class="content-with-sidebar min-vh-100 pb7 pb0-ns">
@@ -67,7 +67,7 @@
 
   {{ block "footer" . }}{{ partialCached "site-footer.html" . }}{{ end }}
   
-  {{ partial "hooks/before-body-end" . }}
+  {{ partial "hooks/before-body-end.html" . }}
   
 
 </body>

--- a/layouts/_default/page.html
+++ b/layouts/_default/page.html
@@ -24,7 +24,7 @@
 
   <!--
   NOTE: Removed to test builds without it.
-  partial "components/author-github-data" (dict "context" . "size" "110") -->
+  partial "components/author-github-data.html" (dict "context" . "size" "110") -->
 </aside>
 
 {{ with .Params.featured_image_path }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,27 +1,27 @@
 {{ define "header" }}
-  {{ partial "hero" . }}
-  {{ partial "boxes-small-news" . }}
+  {{ partial "hero.html" . }}
+  {{ partial "boxes-small-news.html" . }}
 {{ end }}
 
 {{ define "main" }}
   <section class="w-100 ph4 ph5-ns pv4">
-    {{- partial "home-page-sections/features-icons" . -}}
+    {{- partial "home-page-sections/features-icons.html" . -}}
   </section>
 
   {{ partial "home-page-sections/sponsors.html" (dict "cx" . "gtag" "home" ) }}
 
-  {{- partial "home-page-sections/features-single" . -}}
+  {{- partial "home-page-sections/features-single.html" . -}}
 
   {{- partial "home-page-sections/showcase.html" . -}} 
 
   <section class="w-100 ph4 ph5-ns pv4 pv6-ns mid-gray bg-white bb bt b--light-gray">
-    {{- partial "home-page-sections/installation" . -}}
+    {{- partial "home-page-sections/installation.html" . -}}
   </section>
 
   <section class="w-100 ph4 ph5-ns pv4 pv6-ns mid-gray bg-accent-color-dark">
-    {{- partial "home-page-sections/tweets" . -}}
+    {{- partial "home-page-sections/tweets.html" . -}}
   </section>
   <section class="w-100 ph4 ph5-ns pt4 pb5 mid-gray bg-primary-color-light bb bt b--light-gray ">
-    {{- partial "home-page-sections/open-source-involvement" . -}}
+    {{- partial "home-page-sections/open-source-involvement.html" . -}}
   </section>
 {{ end }}

--- a/layouts/news/list.html
+++ b/layouts/news/list.html
@@ -28,7 +28,7 @@
     <section class="flex-ns flex-wrap justify-between w-100 w-80-nsTK v-top">
       {{ $paginator := .Paginate (.Pages | lang.Merge (where .Sites.First.RegularPages "Section" .Section)) -}}
       {{ range $paginator.Pages }}
-        {{ partial "boxes-section-summaries" (dict "context" . "classes" $interior_classes "fullcontent" false) }}
+        {{ partial "boxes-section-summaries.html" (dict "context" . "classes" $interior_classes "fullcontent" false) }}
       {{ end }}
     </section>
   </div>

--- a/layouts/partials/nav-top.html
+++ b/layouts/partials/nav-top.html
@@ -9,8 +9,8 @@
     </a>
   </div>
 
-    {{ partial "nav-links" .}}
+    {{ partial "nav-links.html" .}}
   <div class="dn-l">
-    {{ partial "nav-button-open" .}}
+    {{ partial "nav-button-open.html" .}}
   </div>
 </header>


### PR DESCRIPTION
## Summary
Per the discussions below, it's now clear to me that all partial usage should include the file name extension as a suffix. This PR intends to fix all remaining references in the theme to help future Hugo users understand this best practice.

## Sources
- https://github.com/gohugoio/hugo/issues/9603
- https://discourse.gohugo.io/t/duplicate-entries-in-templatemetrics/37459/10
- https://discourse.gohugo.io/t/duplicate-entries-in-templatemetrics/37459/10

## Additional notes
- https://github.com/gohugoio/gohugoioTheme will require a separate effort