### PR TITLE
Make navigation bar sticky for better UX

### DIFF
--- a/assets/css/_stickynav.css
+++ b/assets/css/_stickynav.css
@@ -1,0 +1,5 @@
+.sticky-nav {
+    position: sticky;
+    top: 0;
+    z-index: 1200;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -21,6 +21,7 @@
 @import '_no-js';
 @import '_social-icons';
 @import '_stickyheader';
+@import '_stickynav';
 
 @import '_svg';
 @import '_chroma';

--- a/layouts/partials/site-nav.html
+++ b/layouts/partials/site-nav.html
@@ -1,5 +1,5 @@
 {{ $currentPage := . }}
-<nav class="bg-primary-color-dark pv4 w-100" role="navigation">
+<nav class="bg-primary-color-dark pv4 w-100 sticky-nav" role="navigation">
 
   <div class="center flex-ns flex-wrap items-center justify-start mw9">
 


### PR DESCRIPTION
Especially when scrolling the documentation, it is very tedious to have to scroll back to the top of the page in order to use the search function or navigate to some other link on the site. 

Making the nav bar stick at the top resolves this and allows the use to not worry about how far they scroll and always have quick access to the search function.