### PR TITLE
shortcodes: fixes

### DIFF
--- a/assets/js/menutoggle.js
+++ b/assets/js/menutoggle.js
@@ -1,4 +1,4 @@
-// Grab any element that has the 'js-toggle' class and add an event listner for the toggleClass function
+// Grab any element that has the 'js-toggle' class and add an event listener for the toggleClass function
 var toggleBtns = document.getElementsByClassName('js-toggle')
   for (var i = 0; i < toggleBtns.length; i++) {
     toggleBtns[i].addEventListener('click', toggleClass, false)

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -201,7 +201,7 @@ either of these shortcodes in conjunction with this render hook.
   Validates the fragment portion of a link destination.
 
   @context {string} contentPath The page containing the link.
-  @context {srting} errorLevel The error level when unable to resolve destination; ignore (default), warning, or error.
+  @context {string} errorLevel The error level when unable to resolve destination; ignore (default), warning, or error.
   @context {page} page The page corresponding to the link destination
   @context {struct} parsedURL The link destination parsed by urls.Parse.
   @context {string} renderHookName The name of the render hook.

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -3,7 +3,7 @@ Renders the page using the RenderShortcode method on the Page object.
 
 You must call this shortcode using the {{% %}} notation.
 
-@param {string} (postional parameter 0) The path to the page, relative to the content directory.
+@param {string} (positional parameter 0) The path to the page, relative to the content directory.
 @returns template.HTML
 
 @example {{% include "functions/_common/glob-patterns" %}}

--- a/layouts/shortcodes/list-pages-in-section.html
+++ b/layouts/shortcodes/list-pages-in-section.html
@@ -1,5 +1,5 @@
 {{- /*
-Renders a desciption list of the pages in the given section.
+Renders a description list of the pages in the given section.
 
 Render a subset of the pages in the section by specifying a predefined filter,
 and whether to include those pages.

--- a/layouts/shortcodes/quick-reference.html
+++ b/layouts/shortcodes/quick-reference.html
@@ -1,5 +1,5 @@
 {{/*
-Renders the child sections of the given top-level section, listing each childs's immediate descendants.
+Renders the child sections of the given top-level section, listing each child's immediate descendants.
 
 @param {string} section The top-level section to render.
 @returns template.HTML
@@ -11,7 +11,7 @@ Renders the child sections of the given top-level section, listing each childs's
 {{ with .Get "section" }}
   {{ $section = . }}
 {{ else }}
-  {{ errorf "The %q shortcodes requires a 'section' parameter. See %s" .Name .Postion }}
+  {{ errorf "The %q shortcodes requires a 'section' parameter. See %s" .Name .Position }}
 {{ end }}
 
 {{/* Do not change the markdown indentation, and do not remove blank lines. */}}
@@ -33,5 +33,5 @@ Renders the child sections of the given top-level section, listing each childs's
     {{ end }}
   {{ end }}
 {{ else }}
-  {{ errorf "The %q shortcodes was unable to find the %q section. See %s" .Name $section .Postion }}
+  {{ errorf "The %q shortcodes was unable to find the %q section. See %s" .Name $section .Position }}
 {{ end }}


### PR DESCRIPTION
This PR fixes misspelled `.Position` method names in shortcode `quick-reference`. It also fixes a few typos I spotted.